### PR TITLE
fix(readme): fix output table in readme for commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See: https://conventionalcommits.org/
   with:
     # token to access GitHub API to receive PR commits. Can be passed in using ${{
     # secrets.GITHUB_TOKEN }}
-    token: ""
+    token: ''
 ```
 
 <!-- end usage -->
@@ -42,30 +42,21 @@ See: https://conventionalcommits.org/
 
 <!-- start outputs -->
 
-| **Output**        | **Description**                                          | **Default** | **Required** |
-| :---------------- | :------------------------------------------------------- | ----------- | ------------ |
-| `breaking_commit` | indicates if a breaking commit was found                 |             |              |
-| `breaking_msg`    | returns the breaking message of the last breaking commit |             |              |
-| `commits`         | JSON list of commits in PR.                              |
-
-Format example:
-
-````json
-  [
-    {
-      "invalid": false,
-      "full": "fix(app)!: changed something\n\nThis is a big change\r\n\r\nBREAKING CHANGE: API changed",
-      "type": "fix",
-      "breaking": true,
-      "scope": "app",
-      "message": "changed something",
-      "body": "This is a big change",
-      "breaking_change": "API changed"
-    }
-  ]
-``` |             |              |
-| `count_commits`   | count of commits in PR                                                                                                                                                                                                                                                                                                                                                                               |             |              |
-| `invalid_commits` | indicates if this commit does not match with conventional commits (other values might be empty)                                                                                                                                                                                                                                                                                                      |             |              |
-| `version_type`    | semantic versioning indicator (patch, minor or major)                                                                                                                                                                                                                                                                                                                                                |             |              |
 <!-- end outputs -->
-````
+
+### JSON format example output `commits`
+
+```json
+[
+  {
+    "invalid": false,
+    "full": "fix(app)!: changed something\n\nThis is a big change\r\n\r\nBREAKING CHANGE: API changed",
+    "type": "fix",
+    "breaking": true,
+    "scope": "app",
+    "message": "changed something",
+    "body": "This is a big change",
+    "breaking_change": "API changed"
+  }
+]
+```

--- a/action.yml
+++ b/action.yml
@@ -13,24 +13,7 @@ outputs:
   breaking_msg:
     description: "returns the breaking message of the last breaking commit"
   commits:
-    description: |
-      JSON list of commits in PR.
-
-      Format example:
-      ```json
-        [
-          {
-            "invalid": false,
-            "full": "fix(app)!: changed something\n\nThis is a big change\r\n\r\nBREAKING CHANGE: API changed",
-            "type": "fix",
-            "breaking": true,
-            "scope": "app",
-            "message": "changed something",
-            "body": "This is a big change",
-            "breaking_change": "API changed"
-          }
-        ]
-      ```
+    description: "JSON list of commits in PR"
   count_commits:
     description: "count of commits in PR"
   invalid_commits:


### PR DESCRIPTION
Outputs table was not correctly formatted.
This will add the `outputs.commits` example at the end of the table.