### PR TITLE
use semicolon as delimiter for type input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: "token to access GitHub API to receive PR commits. Can be passed in using {{ secrets.GITHUB_TOKEN }}"
     required: true
   types:
-    default: "fix|feat|revert"
+    default: "fix;feat;revert"
     description: "allow different types in commit message"
     required: false
 outputs:

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,9 @@ async function run(): Promise<void> {
     const gh_token = core.getInput('token')
     const octokit = github.getOctokit(gh_token)
 
-    const types = core.getInput('types')
+    // replace semicolon with vertical bar to fit regex syntax
+    // not directly used because README markdown table would break
+    const types = core.getInput('types').replace(";","|")
 
     const {data: commit_list} = await octokit.rest.pulls.listCommits({
       owner: github.context.repo.owner,


### PR DESCRIPTION
Using semicolon instead of vertical bar as delimitor for Action input
type to ensure the generated README will correctly generated.
Otherways the table for inputs will break.