### PR TITLE
set github.token as default input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,9 @@ description: |
 author: "taskmedia"
 inputs:
   token:
-    description: "token to access GitHub API to receive PR commits. Can be passed in using {{ secrets.GITHUB_TOKEN }}"
-    required: true
+    default: "${{ github.token }}"
+    description: "token to access GitHub API to receive PR commits"
+    required: false
   types:
     default: "fix;feat;revert"
     description: "allow different types in commit message"


### PR DESCRIPTION
using directly the default will not require to specify `with` parameters in workflow