### PR TITLE
add dependencies section to release-drafter

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -13,6 +13,8 @@ categories:
       - "bug"
   - title: "🧰 Maintenance"
     label: "chore"
+  - title: "📜 Dependencies"
+    label: "dependencies"
 
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.


### PR DESCRIPTION
Adding dependabot label `dependencies` to own section in releases