### PR TITLE
use cmds instead of deps to prevent parallel execution

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,13 +7,13 @@ tasks:
       - package
 
   all:
-    deps:
-      - init
-      - build
-      - format
-      - lint
-      - package
-      - test
+    cmds:
+      - task: init
+      - task: build
+      - task: format
+      - task: lint
+      - task: package
+      - task: test
 
   init:
     cmds:


### PR DESCRIPTION
deps in Task will be executed in parallel - this will be a problem when calling task init which downloads npm dependencies.

This fixes release `v0.5.0` (deleted)