### PR TITLE
Allow action to be executed on push

### DIFF
--- a/.github/workflows/act.yml
+++ b/.github/workflows/act.yml
@@ -3,7 +3,7 @@ on: # rebuild any PRs
   workflow_dispatch:
 
 jobs:
-  test: # make sure the action works on a clean machine without building
+  act-test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,14 @@ tasks:
       - build
       - package
 
+  act:pullrequest:
+    cmds:
+      - act pull_request -j 'act-test' -e act/pull-request.json --secret-file act/local.secrets
+
+  act:push:
+    cmds:
+      - act push -j 'act-test' -e act/push.json --secret-file act/local.secrets
+
   all:
     cmds:
       - task: init

--- a/act/README.md
+++ b/act/README.md
@@ -4,5 +4,5 @@ To test this action locally use [nektos/act](https://github.com/nektos/act).
 
 ```bash
 $ npm run build && npm run package
-$ act pull_request -j 'test' -e act/pull-request.json --secret-file act/local.secrets
+$ act pull_request -j 'act-test' -e act/pull-request.json --secret-file act/local.secrets
 ```

--- a/act/push.json
+++ b/act/push.json
@@ -1,0 +1,10 @@
+{
+  "commits": [
+    {
+      "message": "chore(example): this is a example commit\n\nfor testing with nektos/act"
+    },
+    {
+      "message": "feat(example): this is another commit from the same push event"
+    }
+  ]
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,15 @@ async function receiveCommits(): Promise<String[]> {
   const gh_token = core.getInput('token')
   const octokit = github.getOctokit(gh_token)
 
+  // Extract commits from push event
+  if (github.context.payload.commits != null) {
+    core.debug('Extracting commits from push event')
+    for (const c of github.context.payload.commits) {
+      commits.push(c.message)
+    }
+    return commits
+  }
+
   // Extract commits from pull request
   core.debug('Extracting commits from pull request')
   const {data: commit_list} = await octokit.rest.pulls.listCommits({


### PR DESCRIPTION
Currently this Action could be used within pullrequests - but now the commits can also be validated from push.