### PR TITLE
do not use gitignore within act

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,11 +8,11 @@ tasks:
 
   act:pullrequest:
     cmds:
-      - act pull_request -j 'act-test' -e act/pull-request.json --secret-file act/local.secrets
+      - act pull_request -j 'act-test' -e act/pull-request.json --secret-file act/local.secrets --use-gitignore=false
 
   act:push:
     cmds:
-      - act push -j 'act-test' -e act/push.json --secret-file act/local.secrets
+      - act push -j 'act-test' -e act/push.json --secret-file act/local.secrets --use-gitignore=false
 
   all:
     cmds:


### PR DESCRIPTION
otherwise the execution will fail because no module was found.

error was:

```
docker exec cmd=[node /home/ml/github.com/taskmedia/action-conventional-commits/dist/index.js] user= workdir=
| node:internal/modules/cjs/loader:936
|   throw err;
|   ^
| 
| Error: Cannot find module '/home/ml/github.com/taskmedia/action-conventional-commits/dist/index.js'
|     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
|     at Function.Module._load (node:internal/modules/cjs/loader:778:27)
|     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
|     at node:internal/main/run_main_module:17:47 {
|   code: 'MODULE_NOT_FOUND',
|   requireStack: []
| }
```