### PR TITLE
update package.json version on release

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,6 +58,12 @@ tasks:
       # create release branch with binaries
       - git checkout -b release/{{.CLI_ARGS}}
       - git add --force dist/
+
+      # update version
+      - npm version --no-git-tag-version {{.CLI_ARGS}}
+      - git add package.json
+
+      # commit and push release branch
       - 'git commit -m "chore(release): release {{.CLI_ARGS}}"'
       - git push -u origin release/{{.CLI_ARGS}}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "action-conventional-commits",
-  "version": "0.3.0",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "action-conventional-commits",
-      "version": "0.3.0",
+      "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-conventional-commits",
-  "version": "0.3.0",
+  "version": "0.5.2",
   "private": true,
   "description": "Check if your PR commits matching with conventionalcommits",
   "main": "lib/main.js",


### PR DESCRIPTION
As described in #60 the version in `package.json` should always be updated via CICD.