### PR TITLE
publish npm version to main branch; stop creating release branches

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,13 +55,15 @@ tasks:
       - if [ -z "{{.CLI_ARGS}}" ]; then echo "specify release version '$ task release -- v1.2.3'" && exit 1; fi
       - echo "releasing {{.CLI_ARGS}}"
 
+      # update version to main branch
+      - npm version --no-git-tag-version {{.CLI_ARGS}}
+      - git add package.json
+      - 'git commit -m "chore(npm): update version to {{.CLI_ARGS}}"'
+      - git push origin main
+
       # create release branch with binaries
       - git checkout -b release/{{.CLI_ARGS}}
       - git add --force dist/
-
-      # update version
-      - npm version --no-git-tag-version {{.CLI_ARGS}}
-      - git add package.json
 
       # commit and push release branch
       - 'git commit -m "chore(release): release {{.CLI_ARGS}}"'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,7 +67,6 @@ tasks:
 
       # commit and push release branch
       - 'git commit -m "chore(release): release {{.CLI_ARGS}}"'
-      - git push -u origin release/{{.CLI_ARGS}}
 
       # move tag to release commit
       - git tag --force {{.CLI_ARGS}} HEAD


### PR DESCRIPTION
The `package.json` version update now will be updated directly to main branch.
Previously the update only was persisted inside the release branch.

Also the release branch will not longer be created - because the releases only require tags.

- [ ] cleanup old release branches