### PR TITLE
checkout main branch on release checkout-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: main
 
       - name: install Task
         shell: bash


### PR DESCRIPTION
checkout main branch on release checkout-action

otherwise the branch can not be detected in releasing on task release