### PR TITLE
run commit check on push

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,6 +1,8 @@
 name: commits
 
 on:
+  push:
+
   pull_request:
 
 jobs:

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: taskmedia/action-conventional-commits@v0.5.2
+      - uses: taskmedia/action-conventional-commits@v0.7.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           types: "fix;feat;revert;chore"


### PR DESCRIPTION
The conventional-commits check was only running on `pull_request` events.

Since [`v0.6.0`](https://github.com/taskmedia/action-conventional-commits/releases/tag/v0.6.0) the support with `push` event is supported.