### PR TITLE
change input types back to vertical bar

### DIFF
--- a/.github/workflows/act.yml
+++ b/.github/workflows/act.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: ./
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          types: "fix;feat;revert;chore"
+          types: "fix|feat|revert|chore"

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: "skip squash commits"
     required: false
   types:
-    default: "fix;feat;revert"
+    default: "fix|feat|revert"
     description: "allow different types in commit message"
     required: false
 outputs:

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ async function run(): Promise<void> {
 
     // replace semicolon with vertical bar to fit regex syntax
     // not directly used because README markdown table would break
-    const types = core.getInput('types').replace(/;/g, '|')
+    const types = core.getInput('types')
 
     const skipMerge = /true/i.test(core.getInput('skip_merge'))
     const skipRevert = /true/i.test(core.getInput('skip_revert'))


### PR DESCRIPTION
instead of semicolon the vertical bar (`|`) will be used to specify different types

BREAKING CHANGE: input `types` changed