### PR TITLE
revert bitflight-devops/github-action-readme-generator v1.3.14

### DIFF
--- a/.github/workflows/readme-docs.yml
+++ b/.github/workflows/readme-docs.yml
@@ -18,7 +18,7 @@ jobs:
           # use PAT because main branch is a protected branch
           token: ${{ secrets.PAT }}
 
-      - uses: bitflight-devops/github-action-readme-generator@v1.3.14
+      - uses: bitflight-devops/github-action-readme-generator@v1.1.10
         with:
           pretty: "prettier"
           title_prefix: "GitHub Action: "


### PR DESCRIPTION
Revert "chore(deps): bump bitflight-devops/github-action-readme-generator"

This reverts commit c181f6d7d318923b94716d707fbfe0f7185a315b.

This release does not format the README well.