### PR TITLE
only trigger commits workflow on main branch on push event

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -2,6 +2,8 @@ name: commits
 
 on:
   push:
+    branches:
+      - main
 
   pull_request:
 


### PR DESCRIPTION
currently the check runs on PR twice - `push` and `pull_request` events