### PR TITLE
add repo information to labeling cmd

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -20,4 +20,7 @@ jobs:
         if: github.event_name == 'pull_request' && github.event.action == 'opened'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr edit ${{ github.event.number }} --add-label "${{ steps.cc.outputs.version_type }}"
+        run: |
+          gh pr edit ${{ github.event.number }} \
+            --add-label "${{ steps.cc.outputs.version_type }}" \
+            --repo taskmedia/action-conventional-commits


### PR DESCRIPTION
because the repo is not checked out the repository has to be specified