### PR TITLE
fix(cicd): use chore type for readme wf commits

### DIFF
--- a/.github/workflows/readme-docs.yml
+++ b/.github/workflows/readme-docs.yml
@@ -34,6 +34,6 @@ jobs:
       - name: commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: "docs: autoupdated README"
+          commit_message: "chore(doc): autoupdated README"
           file_pattern: README.md
           push_options: "--force"


### PR DESCRIPTION
Old message `docs: autoupdated README` (f515684268ac44f3bf634bb12b025acd82473c10) failed due commit message.