### PR TITLE
chore(cicd): remove ref in checkout of release wf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v3
         with:
-          ref: main
           # use PAT because main branch is a protected branch
           token: ${{ secrets.PAT }}
 


### PR DESCRIPTION
The `ref` should not be required to checkout the repo on the release.

This could allow to release from other branches.