### PR TITLE
fix(cicd): fetch git before checkout in release task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,6 +56,7 @@ tasks:
       - echo "releasing {{.CLI_ARGS}}"
 
       # ensure main branch
+      - git fetch
       - git checkout main
 
       # update version to main branch


### PR DESCRIPTION
Release v1.1.1 failed in [run](https://github.com/taskmedia/action-conventional-commits/actions/runs/4861003400).