### PR TITLE
fix: force release base commit to sucessfully return

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
           /repos/${{ github.repository }}/releases/latest \
           | jq '.body' \
           | grep -Eo '<!-- base-commit: [a-z0-9]+ -->' \
-          | cut -d ' ' -f3)
+          | cut -d ' ' -f3 \
+          || true)
 
         echo "base-commit-sha: ${RELEASE_BASE_COMMIT}"
         echo "sha=${RELEASE_BASE_COMMIT}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         RELEASE_BASE_COMMIT=$(gh api \
           /repos/${{ github.repository }}/releases/latest \
           | jq '.body' \
-          | grep -Eo '<!-- base-commit: [a-z0-9]+ -->' \
+          | grep -Eo '<!-- base-commit: [0-9a-f]{5,40} -->' \
           | cut -d ' ' -f3 \
           || true)
 


### PR DESCRIPTION
The command should always succeed - if not the workflow will fail. With this change it will not longer fail but return a empty string.