### PR TITLE
chore: remove forced version 1.1.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,6 @@ jobs:
     - uses: google-github-actions/release-please-action@v3
       id: rpa
       with:
-        # temporary fix to set correct release version
-        release-as: 1.1.6
         last-release-sha: ${{ steps.base-commit.outputs.sha }}
         # prerelease will be published later from orphan commit
         prerelease: true


### PR DESCRIPTION
Reverts taskmedia/action-conventional-commits#332

After `v1.1.6` is released the forced release version needs to be removed to automatically calculate the new version.